### PR TITLE
[v2.2.5] Fix Special Track Attachment

### DIFF
--- a/.github/workflows/build-dev-release.yml
+++ b/.github/workflows/build-dev-release.yml
@@ -46,6 +46,7 @@ jobs:
           gh release create "$TAG" \
             --target dev \
             --title "Development Build (Unpackaged)" \
-            --prerelease
+            --prerelease \
+            --draft=false
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scenery/reds_panels_and_operators/README.html
+++ b/scenery/reds_panels_and_operators/README.html
@@ -114,65 +114,72 @@
             <li>Fixed Special Track attachment not rotating properly for all scenery objects that can attach. (Thanks to Caos for reporting it)</li>
           </ul>
         </li>
-        <li>[v2.2.4] Add Bidirectional Support to Switches
-          <ul>
-            <li>Renamed "Special Track" function to "Special Track (Position)" for switches.</li>
-            <li>Replaced "Special Track (No Interaction)" function with "Special Track (Momentary)", which now acts like an interactable momentary switch (intended to be used with "Transfer Table (Left-N-Right)" placard).</li>
-            <li>Added the ability to press <code>CTRL + Click</code> to twist the Binary & Key Switches left (in addition to <code>Click</code> for right) for the following functions: Special Track (Position), Special Track (Momentary), and Operation Mode. This allows all states of these functions to be accessed via interaction. (Thanks to kuba1904zap for suggesting it)</li>
-          </ul>
-        </li>
-        <li>[v2.2.3] New Pilot Light (4-Way) Function & Bug Fixes
-          <ul>
-            <li>Added "Special Track" and "Special Track (Inverse)" Functions to the Pilot Light (4-Way).</li>
-            <li>Fixed an issue where Push Buttons using the "Station Dispatch" Function with a station before or after an automatic switch track (eg. a dual station setup) would not press to first move the track(s) into position. (Thanks to Gamearoo for reporting it)</li>
-            <li>Other small QoL fixes.</li>
-          </ul>
-        </li>
-        <li>[v2.2.2] Fix Button "Special Track Left/Right" Function Bug
-          <ul>
-            <li>Hotfix for the Push Button "Special Track Left/Right" functions not being enabled/disabled when they should be. (Thanks to Ki(c)k for reporting it)</li>
-            <li>Added "Transfer Table Left" & "Transfer Table Right" Placard textures.</li>
-            <li>Added Photoshop and GIMP templates for making custom Placards.</li>
-            <li>Added Transfer Table Left & Right buttons to the swinging coaster in the demo park to showcase them.</li>
-            <li>Removed a bunch of trees/bushes in the demo park to hopefully improve performance.</li>
-          </ul>
-        </li>
-        <li>[v2.2.1] Fix Button "Restraints" Function Bug
-          <ul>
-            <li>Hotfix for the Push Button "Restraints" function lighting the button up when it should be disabled. (Thanks to Waldo Lahr for reporting it)</li>
-          </ul>
-        </li>
-        <li>[v2.2] New Functions & Bug Fix
-          <ul>
-            <li><a href="https://github.com/lilkingjr1/Reds-Panels-and-Operators/releases/tag/v2.2">Change List</a></li>
-          </ul>
-        </li>
-        <li>[v2.1] Add Play Sound Button Function
-          <ul>
-            <li><a href="https://github.com/lilkingjr1/Reds-Panels-and-Operators/releases/tag/v2.1">Change List</a></li>
-          </ul>
-        </li>
-        <li>[v2.0] Operator Interactions, Lights, & Sounds Update
-          <ul>
-            <li><a href="https://github.com/lilkingjr1/Reds-Panels-and-Operators/releases/tag/v2.0">Change List</a></li>
-          </ul>
-        </li>
-        <li>[v1.3] General QoL Improvements & Fixes
-          <ul>
-            <li><a href="https://github.com/lilkingjr1/Reds-Panels-and-Operators/releases/tag/v1.3">Change List</a></li>
-          </ul>
-        </li>
-        <li>[v1.2] Small Extras Added
-          <ul>
-            <li><a href="https://github.com/lilkingjr1/Reds-Panels-and-Operators/releases/tag/v1.2">Change List</a></li>
-          </ul>
-        </li>
-        <li>[v1.1] Texture Hotfix
-          <ul>
-            <li>Fixed a small texture issue on the audio panel of all the medium Main Panels. (Thanks to Luco for reporting it)</li>
-          </ul>
-        </li>
       </ul>
+      <details>
+        <summary>
+          <u><i>Click here to expand log history</i></u>
+        </summary>
+        <ul>
+          <li>[v2.2.4] Add Bidirectional Support to Switches
+            <ul>
+              <li>Renamed "Special Track" function to "Special Track (Position)" for switches.</li>
+              <li>Replaced "Special Track (No Interaction)" function with "Special Track (Momentary)", which now acts like an interactable momentary switch (intended to be used with "Transfer Table (Left-N-Right)" placard).</li>
+              <li>Added the ability to press <code>CTRL + Click</code> to twist the Binary & Key Switches left (in addition to <code>Click</code> for right) for the following functions: Special Track (Position), Special Track (Momentary), and Operation Mode. This allows all states of these functions to be accessed via interaction. (Thanks to kuba1904zap for suggesting it)</li>
+            </ul>
+          </li>
+          <li>[v2.2.3] New Pilot Light (4-Way) Function & Bug Fixes
+            <ul>
+              <li>Added "Special Track" and "Special Track (Inverse)" Functions to the Pilot Light (4-Way).</li>
+              <li>Fixed an issue where Push Buttons using the "Station Dispatch" Function with a station before or after an automatic switch track (eg. a dual station setup) would not press to first move the track(s) into position. (Thanks to Gamearoo for reporting it)</li>
+              <li>Other small QoL fixes.</li>
+            </ul>
+          </li>
+          <li>[v2.2.2] Fix Button "Special Track Left/Right" Function Bug
+            <ul>
+              <li>Hotfix for the Push Button "Special Track Left/Right" functions not being enabled/disabled when they should be. (Thanks to Ki(c)k for reporting it)</li>
+              <li>Added "Transfer Table Left" & "Transfer Table Right" Placard textures.</li>
+              <li>Added Photoshop and GIMP templates for making custom Placards.</li>
+              <li>Added Transfer Table Left & Right buttons to the swinging coaster in the demo park to showcase them.</li>
+              <li>Removed a bunch of trees/bushes in the demo park to hopefully improve performance.</li>
+            </ul>
+          </li>
+          <li>[v2.2.1] Fix Button "Restraints" Function Bug
+            <ul>
+              <li>Hotfix for the Push Button "Restraints" function lighting the button up when it should be disabled. (Thanks to Waldo Lahr for reporting it)</li>
+            </ul>
+          </li>
+          <li>[v2.2] New Functions & Bug Fix
+            <ul>
+              <li><a href="https://github.com/lilkingjr1/Reds-Panels-and-Operators/releases/tag/v2.2">Change List</a></li>
+            </ul>
+          </li>
+          <li>[v2.1] Add Play Sound Button Function
+            <ul>
+              <li><a href="https://github.com/lilkingjr1/Reds-Panels-and-Operators/releases/tag/v2.1">Change List</a></li>
+            </ul>
+          </li>
+          <li>[v2.0] Operator Interactions, Lights, & Sounds Update
+            <ul>
+              <li><a href="https://github.com/lilkingjr1/Reds-Panels-and-Operators/releases/tag/v2.0">Change List</a></li>
+            </ul>
+          </li>
+          <li>[v1.3] General QoL Improvements & Fixes
+            <ul>
+              <li><a href="https://github.com/lilkingjr1/Reds-Panels-and-Operators/releases/tag/v1.3">Change List</a></li>
+            </ul>
+          </li>
+          <li>[v1.2] Small Extras Added
+            <ul>
+              <li><a href="https://github.com/lilkingjr1/Reds-Panels-and-Operators/releases/tag/v1.2">Change List</a></li>
+            </ul>
+          </li>
+          <li>[v1.1] Texture Hotfix
+            <ul>
+              <li>Fixed a small texture issue on the audio panel of all the medium Main Panels. (Thanks to Luco for reporting it)</li>
+            </ul>
+          </li>
+        </ul>
+      </details>
       <hr>
       <h3>
         <u>Credits / Acknowledgment:</u>

--- a/scenery/reds_panels_and_operators/README.html
+++ b/scenery/reds_panels_and_operators/README.html
@@ -17,7 +17,7 @@
         Red's Panels &amp; Operators<br>
         ©2026 David W. (Red-Thirten)<br>
         <a href="mailto:red_thirten@yahoo.com">red_thirten@yahoo.com</a><br>
-        Version 2.2.4, 15 February 2026<br>
+        Version 2.2.5, 18 February 2026<br>
         NL2 Scenery Custom Object (SCO) Package<br>
       </h4></i>
       <hr>
@@ -109,6 +109,11 @@
         <u>Change Log:</u>
       </h3>
       <ul>
+        <li>[v2.2.5] Fix Special Track Attachment
+          <ul>
+            <li>Fixed Special Track attachment not rotating properly for all scenery objects that can attach. (Thanks to Caos for reporting it)</li>
+          </ul>
+        </li>
         <li>[v2.2.4] Add Bidirectional Support to Switches
           <ul>
             <li>Renamed "Special Track" function to "Special Track (Position)" for switches.</li>

--- a/scenery/reds_panels_and_operators/scripts/obj/Speakers.nlvm
+++ b/scenery/reds_panels_and_operators/scripts/obj/Speakers.nlvm
@@ -1,7 +1,7 @@
 /**
 	Speakers Object NL2 Script
 	David Wolfe (Red-Thirten)
-	06/06/2024
+	02/17/2026
 	A Java object representing one or more speakers that can be easily initialized given
 		a list of SCOs and a sound resource path to play on all speakers when called.
 	Licensed under GNU GPLv3 - See LICENSE for more details.
@@ -69,7 +69,7 @@ public class Speakers{
 	private Vector3f getElementTransOrScoTrans(SceneObject sco, String elementName){
 		SceneObjectElement element = sco.getElementForName(elementName);
 		if (element != null){
-			return element.getAbsoluteMatrix().getTrans();
+			return element.getAbsoluteTranslation();
 		}
 		else{
 			return sco.getTranslation();

--- a/scenery/reds_panels_and_operators/scripts/util/SpecialTrackModule.nlvm
+++ b/scenery/reds_panels_and_operators/scripts/util/SpecialTrackModule.nlvm
@@ -1,7 +1,7 @@
 /**
 	Special Track Module NL2 Script
 	David Wolfe (Red-Thirten)
-	03/03/2024
+	02/17/2026
 	A Java object representing a logic entity that will attach a given SCO to a specified
 		coaster Special Track during run time, relative to where it was placed initially.
 	Licensed under GNU GPLv3 - See LICENSE for more details.
@@ -11,30 +11,31 @@
 			(SCO must have a Special Track Parameter named "special_track_attach")
 
 	Methods:
-		void updateTranslation() - Should be called every frame to set the translation of the SCO relative to the Special Track's current location (translation)
+		void updateTranslation() - Should be called every frame to set the matrix of the SCO relative to the Special Track's current coordinate system
 */
 
 package util;
 
 import com.nolimitscoaster.SceneObject;
 import com.nolimitscoaster.SpecialTrack;
-import nlvm.math3d.Vector3f;
+import nlvm.math3d.Matrix4x4f;
 
 public class SpecialTrackModule{
 	private SceneObject sco;
 	private SpecialTrack specialTrack;
-	private Vector3f translationFromSpecialTrackToSCO;
+	private Matrix4x4f localTransform;
 	
 	public SpecialTrackModule(SceneObject sco){ // Default object constructor
 		this.sco = sco; // Assign SCO
 		specialTrack = sco.getSpecialTrackParameter("special_track_attach");
-		translationFromSpecialTrackToSCO = new Vector3f( sco.getTranslation() ); // Get the SCO's translation
-		translationFromSpecialTrackToSCO.sub( specialTrack.getMoveableBranchMatrix(0).getTrans() ); // Subtract the Special Track's translation to get the translation between the two
+		localTransform = specialTrack.getMoveableBranchMatrix(0); // Get track's initial matrix
+		localTransform.invert(); // Invert track initial
+		localTransform.multRight(sco.getMatrix()); // Compute local transform
 	}
 	
 	public void updateTranslation(){
-		Vector3f scoTranslation = new Vector3f( specialTrack.getMoveableBranchMatrix(0).getTrans() );
-		scoTranslation.add(translationFromSpecialTrackToSCO);
-		sco.setTranslation(scoTranslation);
+		Matrix4x4f scoMatrix = specialTrack.getMoveableBranchMatrix(0);
+		scoMatrix.multRight(localTransform);
+		sco.setMatrix(scoMatrix);
 	}
 }


### PR DESCRIPTION
- Fixed Special Track attachment not rotating properly for all scenery objects that can attach (it only did translation before).
- Made Speakers.nlvm slightly more efficient.
- Updated README.html and added expanding collapsible for older change logs.
- Fixed Github workflow to properly release prereleases instead of draft them.